### PR TITLE
changing service name at the beginning of play

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,11 @@
 ---
 # tasks file for verygood.hardening
 
+- name: define ssh service name
+  set_fact:
+    ssh_service_name: 'sshd'
+  when: ansible_distribution == 'CentOS'
+
 - name: auto logout for shell
   template: src=shell-timeout.sh.j2 dest=/etc/profile.d/shell-timeout.sh mode=0644 owner=root group=root
   when: vg_hardening_shell_timeout_seconds > 0
@@ -42,7 +47,3 @@
 - name: removing world write/execute permissions from python dist packages
   file: dest=/usr/local/lib/python2.7/dist-packages recurse=yes state=directory mode="o-wx"
 
-- name: define ssh service name
-  set_fact:
-    ssh_service_name: 'sshd'
-  when: ansible_distribution == 'CentOS'


### PR DESCRIPTION
this is needed, otherwise we will have execution error:
```
RUNNING HANDLER [verygood.hardening : restart sshd] ****************************
fatal: [127.0.0.1]: FAILED! => {"changed": false, "failed": true, "msg": "no service or tool found for: ssh"}
```