### PR TITLE
[INFRA-12654] Fix SSH handler for Ubuntu 24.04 socket activation

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,7 @@
 ---
 # handlers file for verygood.hardening
+# Note: Using state=restarted instead of state=reloaded for Ubuntu 24.04+
+# compatibility. Ubuntu 24.04 uses socket activation (ssh.socket) by default,
+# so ssh.service may not be "active" during Packer builds.
 - name: restart sshd
-  service: name={{ ssh_service_name }} enabled=yes state=reloaded
+  service: name={{ ssh_service_name }} enabled=yes state=restarted


### PR DESCRIPTION
## Summary
- Fix SSH handler failure during Packer AMI builds on Ubuntu 24.04
- Changed `state=reloaded` to `state=restarted` in the restart sshd handler

## Problem
Ubuntu 24.04 (noble) uses socket activation (`ssh.socket`) by default instead of running `ssh.service` continuously. During Packer AMI builds, the SSH connection is managed by Packer directly, so `ssh.service` is not in an "active" state. The `reload` command requires the service to be active, causing the error:

```
Unable to reload service ssh: ssh.service is not active, cannot reload.
```

## Solution
Use `state=restarted` instead of `state=reloaded`. This will start the service if it's not running, then restart it - handling both traditional and socket-activated SSH configurations.

## Test plan
- [ ] Verify Ubuntu AMI build succeeds in vgs-ami CI